### PR TITLE
Rate func refactor

### DIFF
--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -8,6 +8,7 @@ const config = js.readFileSync(confFileName)
 const jsonFormat = require('json-format')
 
 const coinMarketCapExcludeLookup = config.coinMarketCapExcludeLookup || []
+const coinApiRateLookupError = 'COINAPI_RATE_PAIR_ERROR'
 
 export type TxData = {
   txCount: number,
@@ -83,7 +84,7 @@ async function queryCoinApi (currencyCode: string, date: string) {
     })
     const jsonObj = await response.json()
     if (!jsonObj.rate) {
-      throw new Error('No rate from CoinAPI')
+      return coinApiRateLookupError
     }
     return jsonObj.rate.toString()
   } catch (e) {
@@ -357,6 +358,9 @@ async function getHistoricalUsdRate (currencyCode: string, date: string) {
     }
   }
   ratesLoaded = true
+  if (ratePairs[date][currencyCode] === coinApiRateLookupError) {
+    return ''
+  }
 
   let rate = ''
   // if the currency has a pair for the date

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -12,8 +12,6 @@ const coinApiRateLookupError = 'COINAPI_RATE_PAIR_ERROR'
 
 export type TxData = {
   txCount: number,
-  // avgBtc: string,
-  // avgUsd: string,
   currencyAmount: { [currencyCode: string]: string },
   amountBtc: string,
   amountUsd: string,
@@ -52,14 +50,6 @@ let ratePairs: { [date: string]: { [code: string]: string } } = {}
 let ratesLoaded = false
 let btcRates = {}
 let btcRatesLoaded = false
-
-// type getBtcRateOptions = {
-//   from: string,
-//   to: string,
-//   year: string,
-//   month: string,
-//   day: string
-// }
 
 function clearCache () {
   ratePairs = {}
@@ -438,81 +428,6 @@ async function getCurrentUsdRate (currencyCode: string) {
   }
 }
 
-// problematic routine, should be called "getHistoricalRate"?
-// async function getBtcRate (opts: getBtcRateOptions): Promise<string> {
-//   const { from, to, year, month, day } = opts
-//   const date = `${year}-${month}-${day}`
-//   const pair = `${from}_${to}`
-//
-//   let fromToUsd
-//   let toToUsd
-//   try {
-//     // if the pair data already exists in memory (no date, though)...
-//     if (btcRates[pair]) {
-//       // these rates are not historical, only ad-hoc
-//       // console.log('ad-hoc crypto-to-BTC rates are available in memory')
-//     }
-//     fromToUsd = await getHistoricalUsdRate(from.toUpperCase(), date)
-//     toToUsd = await getHistoricalUsdRate(to.toUpperCase(), date)
-//     // const finalRate = bns.div(fromToUsd, toToUsd, 8)
-//     const finalRate = bns.div('1', '1', 8)
-//     return finalRate
-//   } catch (e) {
-//     try {
-//       // if the ad-hoc rates have not been loaded, then load them
-//       if (!btcRatesLoaded) {
-//         // check btcRates
-//         try {
-//           btcRates = js.readFileSync('./cache/btcRates.json')
-//         } catch (e) {
-//           console.log(e)
-//         }
-//         btcRatesLoaded = true
-//       }
-//       // and try to return the rate
-//       if (btcRates[pair]) {
-//         return btcRates[pair]
-//       }
-//       // if coincap.io has not been queried yet, query and store results
-//       if (!_coincapResults) {
-//         const request = `https://api.coincap.io/v2/assets`
-//         const response = await fetch(request)
-//         _coincapResults = await response.json()
-//       }
-//       for (const c of _coincapResults.data) {
-//         if (c.symbol.toUpperCase() === from.toUpperCase()) {
-//           fromToUsd = c.priceUsd
-//         }
-//         if (c.symbol.toUpperCase() === to.toUpperCase()) {
-//           toToUsd = c.priceUsd
-//         }
-//         if (fromToUsd && toToUsd) {
-//           break
-//         }
-//       }
-//
-//       // Try to get fiat rates
-//       if (!fromToUsd) {
-//         fromToUsd = await getFiatRate(from, 'USD')
-//       }
-//       if (!toToUsd) {
-//         toToUsd = await getFiatRate(to, 'USD')
-//       }
-//
-//       // write ad-hoc rates to btcRates.json and return rates
-//       if (fromToUsd && toToUsd) {
-//         const rate = bns.div(fromToUsd, toToUsd, 8)
-//         btcRates[pair] = rate
-//         js.writeFileSync('./cache/btcRates.json', btcRates)
-//         return rate
-//       }
-//       return '0'
-//     } catch (e) {
-//       throw e
-//     }
-//   }
-// }
-
 /*
  * Finds the exchange rate from one fiat currency to another.
  * Returns: String w/ float-value or undefined if either currency is not found
@@ -556,13 +471,6 @@ function findInExchangeRate (fiatCurrency: string) {
   }
   return undefined
 }
-
-// {
-//   "time": "2019-04-26T23:59:59.6886775Z",
-//   "asset_id_base": "BTC",
-//   "asset_id_quote": "USD",
-//   "rate": 5242.7856103737234839148323278
-// }
 
 function pad (num, size) {
   let s = num + ''

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -69,8 +69,18 @@ function clearCache () {
 }
 
 async function queryCoinApiForUsdRate (currencyCode: string, date: string) {
+  const currentTimestamp = Date.now()
+  const targetDate = new Date(date)
+  const targetTimestamp = targetDate.getTime()
+  // if less than 90 days old (cmc API restriction) <<== Is this true for CoinApi?
+  const soonerThan90Days = currentTimestamp - targetTimestamp < 89 * 86400 * 1000
+  const isApiKeyConfigured = config.coinApiKey
   const isCurrencyExcluded = coinMarketCapExcludeLookup.find(c => c === currencyCode.toUpperCase())
-  if (config.coinApiKey && !isCurrencyExcluded) {
+  if (
+    soonerThan90Days &&
+    isApiKeyConfigured &&
+    !isCurrencyExcluded
+  ) {
     const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD?time=${date}T00:00:00.0000000Z&apiKey=${config.coinApiKey}`
     try {
       const response = await fetch(url, {

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -68,7 +68,6 @@ function clearCache () {
   btcRatesLoaded = false
 }
 
-// only queries altcoin to USD
 async function queryCoinApiForUsdRate (currencyCode: string, date: string, hasCoinApiRateLookupError: boolean) {
   if (
     config.coinApiKey &&
@@ -101,14 +100,6 @@ async function queryCoinApiForUsdRate (currencyCode: string, date: string, hasCo
   }
 }
 
-// {
-//   "time": "2019-04-26T23:59:59.6886775Z",
-//   "asset_id_base": "BTC",
-//   "asset_id_quote": "USD",
-//   "rate": 5242.7856103737234839148323278
-// }
-
-// only queries altcoin to USD
 async function queryCoinMarketCapForUsdRate (currencyCode: string, date: string) {
   const currentTimestamp = Date.now()
   const targetDate = new Date(date)
@@ -379,7 +370,7 @@ function updateRatePairs (currencyCode: string, date: string, usdRate: string) {
   js.writeFileSync('./cache/ratePairs.json', ratePairs)
 }
 
-async function getHistoricalUsdRate (currencyCode: string, date: string): Promise<string> {
+async function getHistoricalUsdRate (currencyCode: string, date: string) {
   // eslint-disable-next-line prefer-const
   let {rate: usdRate, hasCoinApiRateLookupError} = queryRatePairs(currencyCode, date)
   if (!usdRate) {
@@ -393,7 +384,7 @@ async function getHistoricalUsdRate (currencyCode: string, date: string): Promis
     updateRatePairs(currencyCode, date, usdRate)
   }
 
-  return 'usdRate'
+  return usdRate
 }
 
 // function queryBtcRates (currencyCode: string) {
@@ -439,50 +430,6 @@ async function getHistoricalUsdRate (currencyCode: string, date: string): Promis
 //   return usdRate || '0'
 // }
 
-// gets specific USD rates for date from ratePairs.json
-// async function getHistoricalUsdRate (currencyCode: string, date: string) {
-//   // if the prices have NOT been loaded
-//   if (!ratesLoaded) {
-//     try {
-//       // grab them from the persistent cache
-//       ratePairs = js.readFileSync('./cache/ratePairs.json')
-//     } catch (e) {
-//       console.log(e)
-//     }
-//   }
-//   ratesLoaded = true
-//   const hasCoinApiRateLookupError = ratePairs[date][currencyCode] === coinApiRateLookupError
-//
-//   let rate = ''
-//   // if the currency has a pair for the date
-//   if (ratePairs[date] && ratePairs[date][currencyCode]) {
-//     rate = ratePairs[date][currencyCode]
-//   } else {
-//     // if the date does not exist or does not have a currency rate
-//     if (!ratePairs[date]) {
-//       ratePairs[date] = {} // initialize the date
-//     }
-//     const currentTimestamp = Date.now()
-//     const targetDate = new Date(date)
-//     const targetTimestamp = targetDate.getTime()
-//     // if less than 90 days old (cmc API restriction)
-//     if (!hasCoinApiRateLookupError) {
-//       if (config.coinMarketCapAPiKey && currentTimestamp - targetTimestamp < 89 * 86400 * 1000) {
-//         rate = await queryCoinMarketCapForUsdRate(currencyCode, date)
-//       }
-//     }
-//     if (!rate && config.coinApiKey) {
-//       // only query coinApi if no rate loaded from cache or coinMarketCap
-//       rate = await queryCoinApiForUsdRate(currencyCode, date)
-//     }
-//     if (rate) {
-//       ratePairs[date][currencyCode] = rate
-//       js.writeFileSync('./cache/ratePairs.json', ratePairs)
-//     }
-//   }
-//   return rate
-// }
-
 // problematic routine, should be called "getHistoricalRate"?
 async function getBtcRate (opts: getBtcRateOptions): Promise<string> {
   const { from, to, year, month, day } = opts
@@ -499,7 +446,8 @@ async function getBtcRate (opts: getBtcRateOptions): Promise<string> {
     }
     fromToUsd = await getHistoricalUsdRate(from.toUpperCase(), date)
     toToUsd = await getHistoricalUsdRate(to.toUpperCase(), date)
-    const finalRate = bns.div(fromToUsd, toToUsd, 8)
+    // const finalRate = bns.div(fromToUsd, toToUsd, 8)
+    const finalRate = bns.div('1', '1', 8)
     return finalRate
   } catch (e) {
     try {

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -124,12 +124,13 @@ async function queryCoinMarketCapForUsdRate (currencyCode: string, date: string)
       response = await fetch(url, fetchOptions)
       const jsonObj = await response.json()
       if (!jsonObj || !jsonObj.data || !jsonObj.data.quotes || !jsonObj.data.quotes[0] || !jsonObj.data.quotes[0].quote || !jsonObj.data.quotes[0].quote.USD) {
-        throw new Error(`No rate from CMC: ${currencyCode}`)
+        console.log(`No rate from CMC: ${currencyCode} date:${date} response.status:${response.status}`)
+        return ''
       }
       return jsonObj.data.quotes[0].quote.USD.price.toString()
     } catch (e) {
-      console.log(`No CoinMarketCap ${currencyCode} quote: `, e)
-      throw e
+      console.log(`No CoinMarketCap ${currencyCode} date:${date} quote: `, e)
+      return ''
     }
   } else {
     return ''

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -253,10 +253,10 @@ async function checkSwapService (
       amountBtc = '0'
       amountUsd = tx.outputAmount
     } else {
-      const btcToUsdRate = await getUsdRate('BTC', dateStr)
-      const txInputToUsdRate = await getUsdRate(tx.inputCurrency, dateStr)
-      if (txInputToUsdRate !== '0') {
-        amountUsd = bns.div(tx.inputAmount.toString(), txInputToUsdRate, 8)
+      const usdPerBtcRate = await getUsdRate('BTC', dateStr)
+      const usdPerTxInputRate = await getUsdRate(tx.inputCurrency, dateStr)
+      if (usdPerTxInputRate !== '0') {
+        amountUsd = bns.mul(tx.inputAmount.toString(), usdPerTxInputRate)
       }
 
       // most partners
@@ -269,15 +269,15 @@ async function checkSwapService (
         let btcToTxInputCurRate = queryBtcRates(tx.inputCurrency)
         if (!btcToTxInputCurRate) {
           // If it's not cached yet then we'll have to generate it the long way...
-          if (txInputToUsdRate !== coinApiRateLookupError && txInputToUsdRate !== '0') {
-            btcToTxInputCurRate = bns.div(btcToUsdRate, txInputToUsdRate, 8)
+          if (usdPerTxInputRate !== coinApiRateLookupError && usdPerTxInputRate !== '0') {
+            btcToTxInputCurRate = bns.div(usdPerTxInputRate, usdPerBtcRate, 8)
           }
           // And update the cache...
           if (btcToTxInputCurRate && btcToTxInputCurRate !== '') {
             updateBtcRate(tx.inputCurrency, btcToTxInputCurRate)
           }
         }
-        amountBtc = bns.mul(btcToTxInputCurRate, tx.inputAmount.toString())
+        amountBtc = bns.mul(tx.inputAmount.toString(), btcToTxInputCurRate)
       }
     }
     // now stick it into the txDataMap

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -7,7 +7,6 @@ const confFileName = './config.json'
 const config = js.readFileSync(confFileName)
 const jsonFormat = require('json-format')
 
-const coinApiExcludeLookup = config.coinApiExcludeLookup || []
 const coinMarketCapExcludeLookup = config.coinMarketCapExcludeLookup || []
 
 export type TxData = {
@@ -70,34 +69,29 @@ function clearCache () {
 
 // only queries altcoin to USD
 async function queryCoinApi (currencyCode: string, date: string) {
-  if (!coinApiExcludeLookup.find(currencyCode.toUpperCase)) {
-    // const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD?time=2017-08-09T12:00:00.0000000Z`
-    const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD?time=${date}T00:00:00.0000000Z&apiKey=${config.coinApiKey}`
-    // const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD`
-    //   if (!doSummary) {
-    //     console.log(url)
-    //   }
-    // console.log('kylan fetched url is: ', url)
-    let response
-    try {
-      response = await fetch(url, {
-        method: 'GET'
-      })
-      const jsonObj = await response.json()
-      if (!jsonObj.rate) {
-        throw new Error('No rate from CoinAPI')
-      }
-      return jsonObj.rate.toString()
-    } catch (e) {
-      // if (!doSummary) {
-      console.log(e)
-      console.log(`${date} ${currencyCode}`)
-      // }
-      throw e
+  // const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD?time=2017-08-09T12:00:00.0000000Z`
+  const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD?time=${date}T00:00:00.0000000Z&apiKey=${config.coinApiKey}`
+  // const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD`
+  //   if (!doSummary) {
+  //     console.log(url)
+  //   }
+  // console.log('kylan fetched url is: ', url)
+  let response
+  try {
+    response = await fetch(url, {
+      method: 'GET'
+    })
+    const jsonObj = await response.json()
+    if (!jsonObj.rate) {
+      throw new Error('No rate from CoinAPI')
     }
-  } else {
-    console.log(`queryCoinApi excluding currencyCode ${currencyCode} from coinapi search`)
-    throw new Error('No rate from CoinAPI')
+    return jsonObj.rate.toString()
+  } catch (e) {
+    // if (!doSummary) {
+    console.log(e)
+    console.log(`${date} ${currencyCode}`)
+    // }
+    throw e
   }
 }
 
@@ -110,7 +104,7 @@ async function queryCoinApi (currencyCode: string, date: string) {
 
 // only queries altcoin to USD
 async function queryCoinMarketCap (currencyCode: string, date: string) {
-  if (!coinMarketCapExcludeLookup.find(currencyCode.toUpperCase)) {
+  if (!coinMarketCapExcludeLookup.find(c => c === currencyCode.toUpperCase())) {
     const url = `https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/historical?symbol=${currencyCode}&time_end=${date}&count=1`
 
     let response

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -69,7 +69,8 @@ function clearCache () {
 }
 
 async function queryCoinApiForUsdRate (currencyCode: string, date: string) {
-  if (config.coinApiKey) {
+  const isCurrencyExcluded = coinMarketCapExcludeLookup.find(c => c === currencyCode.toUpperCase())
+  if (config.coinApiKey && !isCurrencyExcluded) {
     const url = `https://rest.coinapi.io/v1/exchangerate/${currencyCode}/USD?time=${date}T00:00:00.0000000Z&apiKey=${config.coinApiKey}`
     try {
       const response = await fetch(url, {
@@ -265,7 +266,7 @@ async function checkSwapService (
           amountBtc = bns.mul(btcToTxInputCurRate, tx.inputAmount.toString())
         }
       }
-      if (btcToUsdRate) {
+      if (btcToUsdRate && btcToUsdRate !== '0') {
         amountUsd = bns.div(amountBtc, btcToUsdRate, 8)
       } else {
         console.log('Unable to calculate ANY fiat value for: ', tx.inputCurrency)
@@ -332,6 +333,9 @@ function updateRatePairs (currencyCode: string, date: string, usdRate: string) {
 }
 
 async function getUsdRate (currencyCode: string, date: string, includeBtcRates: boolean) {
+  if (currencyCode === 'USD') {
+    return '1'
+  }
   let usdRate = await getHistoricalUsdRate(currencyCode, date)
   if (!usdRate || usdRate === '') {
     usdRate = await getCurrentUsdRate(currencyCode, includeBtcRates)
@@ -359,7 +363,7 @@ async function getHistoricalUsdRate (currencyCode: string, date: string) {
 
     return usdRate
   } else {
-    return '0'
+    return ''
   }
 }
 

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -264,7 +264,9 @@ async function checkSwapService (
     } else {
       const btcToUsdRate = await getUsdRate('BTC', dateStr)
       const txInputToUsdRate = await getUsdRate(tx.inputCurrency, dateStr)
-      amountUsd = bns.div(tx.inputAmount.toString(), txInputToUsdRate, 8)
+      if (txInputToUsdRate !== '0') {
+        amountUsd = bns.div(tx.inputAmount.toString(), txInputToUsdRate, 8)
+      }
 
       // most partners
       if (tx.inputCurrency === 'BTC') {

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -321,9 +321,14 @@ function queryRatePairs (currencyCode: string, date: string) {
 }
 
 function updateRatePairs (currencyCode: string, date: string, usdRate: string) {
-  ratePairs[date] = ratePairs[date] || {}
-  ratePairs[date][currencyCode] = usdRate
-  js.writeFileSync('./cache/ratePairs.json', ratePairs)
+  if (!ratePairs[date]) {
+    ratePairs[date] = {}
+  }
+
+  if (!ratePairs[date][currencyCode]) {
+    ratePairs[date][currencyCode] = usdRate
+    js.writeFileSync('./cache/ratePairs.json', ratePairs)
+  }
 }
 
 async function getUsdRate (currencyCode: string, date: string, includeBtcRates: boolean) {
@@ -377,8 +382,10 @@ function queryBtcRates (currencyCode: string) {
 
 function updateBtcRate (currencyCode: string, rate: string) {
   const pair = `${currencyCode}_BTC`
-  btcRates[pair] = rate
-  js.writeFileSync('./cache/btcRates.json', btcRates)
+  if (!btcRates[pair]) {
+    btcRates[pair] = rate
+    js.writeFileSync('./cache/btcRates.json', btcRates)
+  }
 }
 
 async function queryCoinCap (currencyCode: string) {

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -132,7 +132,6 @@ async function queryCoinMarketCap (currencyCode: string, date: string) {
       throw e
     }
   } else {
-    console.log(`queryCoinMarketCap excluding currencyCode ${currencyCode} from coinapi search`)
     throw new Error('No rate from CMC')
   }
 }

--- a/src/moonpay.js
+++ b/src/moonpay.js
@@ -51,7 +51,7 @@ async function fetchMoonpay (swapFuncParams: SwapFuncParams) {
       headers
     })
     const txs = await result.json()
-    console.log(`Moonpay: offset:${offset} count:${txs.length} url:${url}`)
+    console.log(`Moonpay: offset:${offset} count:${txs.length}`)
 
     for (const tx of txs) {
       if (tx.status === 'completed') {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -15,16 +15,46 @@ const { bns } = require('biggystring')
 const config = require('../config.json')
 
 async function main (swapFuncParams: SwapFuncParams) {
-  const rChn = await doChangenow(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rCha = await doChangelly(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rFaa = await doFaast(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rSsh = await doShapeShift(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rLbx = await doLibertyX(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rBit = await doBitrefill(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rFox = await doFox(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rTl = await doTotle(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rCs = await doCoinswitch(swapFuncParams).catch(e => { console.error('doChangenow failed'); return {} })
-  const rMnp = await doMoonpay(swapFuncParams).catch(e => { console.error('doMoonpay failed'); return {} })
+  const rChn = await doChangenow(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rCha = await doChangelly(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rFaa = await doFaast(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rSsh = await doShapeShift(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rLbx = await doLibertyX(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rBit = await doBitrefill(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rFox = await doFox(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rTl = await doTotle(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rCs = await doCoinswitch(swapFuncParams).catch(e => {
+    console.error('doChangenow failed')
+    return {}
+  })
+  const rMnp = await doMoonpay(swapFuncParams).catch(e => {
+    console.error('doMoonpay failed')
+    return {}
+  })
   printTxDataMap('CHN', rChn)
   printTxDataMap('CHA', rCha)
   printTxDataMap('FAA', rFaa)
@@ -48,7 +78,10 @@ function makeDate (endTime) {
   return `${y}-${m}-${d}`
 }
 
-function combineResults (r1: { [string]: TxDataMap }, r2: { [string]: TxDataMap }) {
+function combineResults (
+  r1: { [string]: TxDataMap },
+  r2: { [string]: TxDataMap }
+) {
   for (const freq in r2) {
     if (r2.hasOwnProperty(freq)) {
       if (!r1[freq]) {
@@ -76,7 +109,10 @@ function combineTxDataMap (r1: TxDataMap, r2: TxDataMap) {
       r1[date].amountUsd = bns.add(r1[date].amountUsd, r2[date].amountUsd)
       for (const cc in r2[date].currencyAmount) {
         if (r1[date].currencyAmount[cc]) {
-          r1[date].currencyAmount[cc] = bns.add(r1[date].currencyAmount[cc], r2[date].currencyAmount[cc])
+          r1[date].currencyAmount[cc] = bns.add(
+            r1[date].currencyAmount[cc],
+            r2[date].currencyAmount[cc]
+          )
         } else {
           r1[date].currencyAmount[cc] = r2[date].currencyAmount[cc]
         }
@@ -85,7 +121,9 @@ function combineTxDataMap (r1: TxDataMap, r2: TxDataMap) {
   }
 }
 
-async function doSummaryFunction (doFunction: Function): { [string]: TxDataMap } {
+async function doSummaryFunction (
+  doFunction: Function
+): { [string]: TxDataMap } {
   // console.log(new Date(Date.now()))
   // console.log('**************************************************')
   // console.log('******* Monthly')
@@ -96,19 +134,23 @@ async function doSummaryFunction (doFunction: Function): { [string]: TxDataMap }
     hourly: {}
   }
 
-  out.monthly = await doFunction({useCache: false, interval: 'month', endDate: '2018-01'})
+  out.monthly = await doFunction({
+    useCache: false,
+    interval: 'month',
+    endDate: '2018-01'
+  })
 
   // console.log('**************************************************')
   let end = Date.now() - 1000 * 60 * 60 * 24 * 60 // 60 days back
   let endDate = makeDate(end)
   // console.log(`******* Daily until ${endDate}`)
-  out.daily = await doFunction({useCache: true, interval: 'day', endDate})
+  out.daily = await doFunction({ useCache: true, interval: 'day', endDate })
 
   // console.log('**************************************************')
   end = Date.now() - 1000 * 60 * 60 * 24 * 2 // 2 days back
   endDate = makeDate(end)
   // console.log(`******* Hourly until ${endDate}`)
-  out.hourly = await doFunction({useCache: true, interval: 'hour', endDate})
+  out.hourly = await doFunction({ useCache: true, interval: 'hour', endDate })
   return out
 }
 
@@ -118,14 +160,19 @@ async function report (argv: Array<any>) {
   console.log(d)
   console.log(d.toDateString() + ' ' + d.toTimeString())
 
-  const swapFuncParams: SwapFuncParams = {useCache: false, interval: 'month', endDate: '2018-01'}
+  const swapFuncParams: SwapFuncParams = {
+    useCache: false,
+    interval: 'month',
+    endDate: '2018-01'
+  }
   let doSummary = false
   for (const arg of argv) {
     if (arg === 'day' || arg === 'month' || arg === 'hour' || arg === 'mins') {
       swapFuncParams.interval = arg
     } else if (arg === 'cache') {
       swapFuncParams.useCache = true
-    } else if (arg === 'summary') { // most common parameter
+    } else if (arg === 'summary') {
+      // most common parameter
       doSummary = true
       break
     } else if (arg === 'nocache') {
@@ -139,16 +186,36 @@ async function report (argv: Array<any>) {
 
   if (doSummary) {
     const results: { [string]: TxDataMap } = {}
-    const cnResults = config.changenowApiKey ? await doSummaryFunction(doChangenow) : {}
-    const chResults = config.changellyApiKey ? await doSummaryFunction(doChangelly) : {}
-    const ssResults = config.shapeShiftApiKey ? await doSummaryFunction(doShapeShift) : {}
-    const faResults = config.faastAffiliateId ? await doSummaryFunction(doFaast) : {}
+    const cnResults = config.changenowApiKey
+      ? await doSummaryFunction(doChangenow)
+      : {}
+    const chResults = config.changellyApiKey
+      ? await doSummaryFunction(doChangelly)
+      : {}
+    const ssResults = config.shapeShiftApiKey
+      ? await doSummaryFunction(doShapeShift)
+      : {}
+    const faResults = config.faastAffiliateId
+      ? await doSummaryFunction(doFaast)
+      : {}
     const tlResults = config.totleApiKey ? await doSummaryFunction(doTotle) : {}
-    const lxResults = config.libertyXApiKey ? await doSummaryFunction(doLibertyX) : {}
-    const btResults = config.bitrefillCredentials && config.bitrefillCredentials.apiKey ? await doSummaryFunction(doBitrefill) : {}
-    const foxResults = config.foxCredentials ? await doSummaryFunction(doFox) : {}
-    const csResults = config.coinswitch && config.coinswitch.apiKey ? await doSummaryFunction(doCoinswitch) : {}
-    const mnpResults = config.moonpayApiKey ? await doSummaryFunction(doMoonpay) : {}
+    const lxResults = config.libertyXApiKey
+      ? await doSummaryFunction(doLibertyX)
+      : {}
+    const btResults =
+      config.bitrefillCredentials && config.bitrefillCredentials.apiKey
+        ? await doSummaryFunction(doBitrefill)
+        : {}
+    const foxResults = config.foxCredentials
+      ? await doSummaryFunction(doFox)
+      : {}
+    const csResults =
+      config.coinswitch && config.coinswitch.apiKey
+        ? await doSummaryFunction(doCoinswitch)
+        : {}
+    const mnpResults = config.moonpayApiKey
+      ? await doSummaryFunction(doMoonpay)
+      : {}
     combineResults(results, cnResults)
     combineResults(results, chResults)
     combineResults(results, faResults)
@@ -156,7 +223,6 @@ async function report (argv: Array<any>) {
     combineResults(results, tlResults)
     combineResults(results, foxResults)
     combineResults(results, csResults)
-    combineResults(results, mnpResults)
 
     console.log('\n***** Change NOW Daily *****')
     printTxDataMap('CHN', cnResults.daily)
@@ -172,16 +238,25 @@ async function report (argv: Array<any>) {
     printTxDataMap('SSH', ssResults.monthly)
     console.log('\n***** Changelly Monthly *****')
     printTxDataMap('CHA', chResults.monthly)
-    console.log('\n***** Libertyx Monthly *****')
-    printTxDataMap('LBX', lxResults.monthly)
-    console.log('\n***** Libertyx Daily *****')
-    printTxDataMap('LBX', lxResults.daily)
     console.log('\n***** Bitrefill Monthly *****')
     printTxDataMap('BIT', btResults.monthly)
     console.log('\n***** Bitrefill Daily *****')
     printTxDataMap('BIT', btResults.daily)
     console.log('\n***** Totle Daily *****')
     printTxDataMap('TOT', tlResults.daily)
+    console.log('\n***** CoinSwitch Daily *****')
+    printTxDataMap('CS', csResults.daily)
+    console.log('\n***** CoinSwitch Monthly *****')
+    printTxDataMap('CS', csResults.monthly)
+    console.log('\n***** Libertyx Monthly *****')
+    printTxDataMap('LBX', lxResults.monthly)
+    console.log('\n***** Libertyx Daily *****')
+    printTxDataMap('LBX', lxResults.daily)
+    console.log('\n***** Moonpay Monthly *****')
+    printTxDataMap('MNP', mnpResults.monthly)
+    console.log('\n***** Moonpay Daily *****')
+    printTxDataMap('MNP', mnpResults.daily)
+
     console.log('\n***** Swap Totals Monthly*****')
     printTxDataMap('TTS', results.monthly)
     console.log('\n***** Swap Totals Daily *****')
@@ -190,6 +265,7 @@ async function report (argv: Array<any>) {
     printTxDataMap('TTS', results.hourly)
     combineResults(results, lxResults)
     combineResults(results, btResults)
+    combineResults(results, mnpResults)
 
     console.log('\n***** Grand Totals Monthly *****')
     printTxDataMap('TTL', results.monthly)
@@ -197,10 +273,6 @@ async function report (argv: Array<any>) {
     printTxDataMap('TTL', results.daily)
     console.log('\n***** Grand Totals Hourly *****')
     printTxDataMap('TTL', results.hourly)
-    console.log('\n***** CoinSwitch Daily *****')
-    printTxDataMap('CS', csResults.daily)
-    console.log('\n***** CoinSwitch Monthly *****')
-    printTxDataMap('CS', csResults.monthly)
     const d = new Date()
     console.log(d)
     console.log(d.toDateString() + ' ' + d.toTimeString())


### PR DESCRIPTION
Changes:
 - Extensive refactor of checkSwapService function
 - Normalize all values on USD (rename functions and variables accordingly
 - Refactor and "stream-line" rate lookup functions (hopefully they are easier to read now)
 - Add "excludes array" for CoinMarketCap ("CMC") and CoinApi.  coinMarketCapExcludeLookup (in config.json)
 - If we're unable to get a proper rate from CMC and CoinApi then set the value in ratePairs.json to "COINAPI_RATE_PAIR_ERROR" so we don't bother trying to query for this pair again
 - Apply the 90-day limit to CoinApi (previously only CoinMarketCap had this limitation - this might not be necessary, i'll look into it further)