### PR TITLE
Refactor checkSwapService rate-query functions

### DIFF
--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -7,6 +7,9 @@ const confFileName = './config.json'
 const config = js.readFileSync(confFileName)
 const jsonFormat = require('json-format')
 
+const coinMarketCapExcludeLookup = config.coinMarketCapExcludeLookup || []
+const coinApiRateLookupError = 'COINAPI_RATE_PAIR_ERROR'
+
 export type TxData = {
   txCount: number,
   // avgBtc: string,

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -12,8 +12,6 @@ const coinApiRateLookupError = 'COINAPI_RATE_PAIR_ERROR'
 
 export type TxData = {
   txCount: number,
-  // avgBtc: string,
-  // avgUsd: string,
   currencyAmount: { [currencyCode: string]: string },
   amountBtc: string,
   amountUsd: string,
@@ -52,14 +50,6 @@ let ratePairs: { [date: string]: { [code: string]: string } } = {}
 let ratesLoaded = false
 let btcRates = {}
 let btcRatesLoaded = false
-
-type getBtcRateOptions = {
-  from: string,
-  to: string,
-  year: string,
-  month: string,
-  day: string
-}
 
 function clearCache () {
   ratePairs = {}
@@ -104,13 +94,6 @@ async function queryCoinApiForUsdRate (currencyCode: string, date: string) {
     return ''
   }
 }
-
-// {
-//   "time": "2019-04-26T23:59:59.6886775Z",
-//   "asset_id_base": "BTC",
-//   "asset_id_quote": "USD",
-//   "rate": 5242.7856103737234839148323278
-// }
 
 async function queryCoinMarketCapForUsdRate (currencyCode: string, date: string) {
   const currentTimestamp = Date.now()
@@ -161,22 +144,6 @@ async function checkSwapService (
   swapFuncParams: SwapFuncParams
 ) {
   clearCache()
-  // const diskCache = js.readFileSync(cacheFile)
-  // const cachedTransactions = diskCache.txs
-  // console.log(`Read txs from cache: ${cachedTransactions.length}`)
-  // let newTransactions = []
-  // if (!useCache) {
-  //   while (newTransactions.length === 0) {
-  //     try {
-  //       const newQuery = await theFetch()
-  //       newTransactions = newQuery.txs
-  //       console.log(`Got new transactions... ${newTransactions.length}`)
-  //     } catch (e) {
-  //       console.log(e)
-  //       return
-  //     }
-  //   }
-  // }
 
   const { endDate } = swapFuncParams
   // diskCache is the [prefix]Raw.json file's transactions and an 'offset' property (that is persistent)
@@ -507,13 +474,6 @@ function findInExchangeRate (fiatCurrency: string) {
   }
   return undefined
 }
-
-// {
-//   "time": "2019-04-26T23:59:59.6886775Z",
-//   "asset_id_base": "BTC",
-//   "asset_id_quote": "USD",
-//   "rate": 5242.7856103737234839148323278
-// }
 
 function pad (num, size) {
   let s = num + ''

--- a/src/checkSwapService.js
+++ b/src/checkSwapService.js
@@ -235,6 +235,7 @@ async function checkSwapService (
     const day = pad(date.getUTCDate(), 2)
     const hour = pad(date.getUTCHours(), 2)
     const mins = pad(date.getUTCMinutes(), 2)
+    const dateStr = `${year.toString()}-${month}-${day}`
 
     let idx
     const { interval } = swapFuncParams
@@ -285,48 +286,31 @@ async function checkSwapService (
       amountBtc = '0'
       amountUsd = tx.outputAmount
     } else {
+      const usdPerBtcRate = await getUsdRate('BTC', dateStr)
+      const usdPerTxInputRate = await getUsdRate(tx.inputCurrency, dateStr)
+      if (usdPerTxInputRate !== '0') {
+        amountUsd = bns.mul(tx.inputAmount.toString(), usdPerTxInputRate)
+      }
+
       // most partners
       if (tx.inputCurrency === 'BTC') {
         amountBtc = tx.inputAmount.toString()
       } else {
         // get exchange currency and convert to BTC equivalent for that date and time
         // then find out equivalent amount of BTC
-        // will try grabbing from cache and then query coincap.io if nothing cached
-        const rate = await getBtcRate({
-          from: tx.inputCurrency,
-          to: 'BTC',
-          year: year.toString(),
-          month,
-          day
-        })
-        // convert BTC to USD
-        amountBtc = bns.mul(rate, tx.inputAmount.toString())
-      }
-      // gets USD value of Bitcoin
-      // getHistoricalUsdRate tries to get rate from ratePairs.json cache
-      // then query coinmarketCap, then coinapi until it finds a
-      // USD rate for the currencyCode and date
-      let btcRate = await getHistoricalUsdRate(
-        'BTC',
-        `${year.toString()}-${month}-${day}`
-      )
-      // converts value in BTC to value in USD
-      if (btcRate) {
-        amountUsd = bns.mul(amountBtc, btcRate)
-      } else {
-        if (!_coincapResults) {
-          const request = `https://api.coincap.io/v2/assets`
-          const response = await fetch(request)
-          _coincapResults = await response.json()
+        // First, check the btcRates cache file...
+        let btcToTxInputCurRate = queryBtcRates(tx.inputCurrency)
+        if (!btcToTxInputCurRate) {
+          // If it's not cached yet then we'll have to generate it the long way...
+          if (usdPerTxInputRate !== coinApiRateLookupError && usdPerTxInputRate !== '0') {
+            btcToTxInputCurRate = bns.div(usdPerTxInputRate, usdPerBtcRate, 8)
+          }
+          // And update the cache...
+          if (btcToTxInputCurRate && btcToTxInputCurRate !== '') {
+            updateBtcRate(tx.inputCurrency, btcToTxInputCurRate)
+          }
         }
-        const btcData = _coincapResults.data.find(currency => currency.symbol.toUpperCase() === 'BTC')
-        if (btcData) {
-          btcRate = btcData.priceUsd
-          amountUsd = bns.mul(amountBtc, btcRate)
-        } else {
-          console.log('Unable to calculate ANY fiat value for: ', tx.inputCurrency)
-          btcRate = '0'
-        }
+        amountBtc = bns.mul(tx.inputAmount.toString(), btcToTxInputCurRate)
       }
     }
     // now stick it into the txDataMap

--- a/src/moonpay.js
+++ b/src/moonpay.js
@@ -51,7 +51,7 @@ async function fetchMoonpay (swapFuncParams: SwapFuncParams) {
       headers
     })
     const txs = await result.json()
-    console.log(`Moonpay: offset:${offset} count:${txs.length} url:${url}`)
+    console.log(`Moonpay: offset:${offset} count:${txs.length}`)
 
     for (const tx of txs) {
       if (tx.status === 'completed') {


### PR DESCRIPTION
Changes:

 - Extensive refactor of checkSwapService function
 - Normalize all values on USD (rename functions and variables accordingly
 - Refactor and "stream-line" rate lookup functions (hopefully they are easier to read now)
 - Add "excludes array" for CoinMarketCap ("CMC") and CoinApi. coinMarketCapExcludeLookup (in config.json)
 - If we're unable to get a proper rate from CMC and CoinApi then set the value in ratePairs.json to "COINAPI_RATE_PAIR_ERROR" so we don't bother trying to query for this pair again
 - Apply the 90-day limit to CoinApi (previously only CoinMarketCap had this limitation - this might not be necessary, i'll look into it further)