### PR TITLE
Bitaccess BTM Cash API integration

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,9 @@
 ; Ignore unexpected extra "@providesModule"
 .*/node_modules/.*/node_modules/fbjs/.*
 
+; Ignore incomplete json
+.*/node_modules/oboe/test/json/incomplete.json
+
 ; Ignore duplicate module providers
 ; For RN Apps installed via npm, "Libraries" folder is inside
 ; "node_modules/react-native" but in the source repo it is in the root

--- a/config.json.sample
+++ b/config.json.sample
@@ -39,5 +39,10 @@
   "switchainApiKey" : "",
   "transak_api_secret": "xxx",
   "coinMarketCapExcludeLookup": ["USD", "EUR", "GBP"],
-  "coinApiExcludeLookup": ["USD", "EUR", "GBP"]
+  "coinApiExcludeLookup": ["USD", "EUR", "GBP"],
+  "bitaccessBtm" : {
+    "affiliateId": "xxx",
+    "apiKey": "xxx",
+    "apiSecret": "xxx"
+  }
 }

--- a/src/bitaccessBtm.js
+++ b/src/bitaccessBtm.js
@@ -1,0 +1,91 @@
+// @flow
+
+import type { StandardTx, SwapFuncParams } from './checkSwapService.js'
+const js = require('jsonfile')
+const crypto = require('crypto')
+const fetch = require('node-fetch')
+const SS_QUERY_PAGES = 3
+const confFileName = './config.json'
+const config = js.readFileSync(confFileName)
+const { checkSwapService } = require('./checkSwapService.js')
+
+const FILE_CACHE = './cache/btmRaw.json'
+const PAGE_LIMIT = 50
+
+async function doBitaccessBtm (swapFuncParams: SwapFuncParams) {
+  return checkSwapService(fetchBitaccessBtm, FILE_CACHE, 'BTM', swapFuncParams)
+}
+
+async function fetchBitaccessBtm (swapFuncParams: SwapFuncParams) {
+  if (!swapFuncParams.useCache) {
+    console.log('Fetching Bitaccess BTM...')
+  }
+  let diskCache = { txs: [] }
+  try {
+    diskCache = js.readFileSync(FILE_CACHE)
+  } catch (e) {}
+  const newTransactions = []
+  let page = 1
+
+  while (1 && !swapFuncParams.useCache) {
+    const requestMethod = 'GET'
+    const bodyHash = ''
+    const contentType = 'application/json'
+    const dateString = new Date().toISOString()
+    const sigString = `${requestMethod}\n${bodyHash}\n${contentType}\n${dateString}`
+    const signature = crypto
+      .createHmac('sha256', config.bitaccessBtm.apiSecret)
+      .update(sigString, 'utf8')
+      .digest('base64')
+    try {
+      const request = `https://cashapi.bitaccessbtm.com/api/v1/affiliate/${config.bitaccessBtm.affiliateId}/transactions?limit=${PAGE_LIMIT}&page=${page}`
+      const options = {
+        method: requestMethod,
+        headers: {
+          Authorization: `HMAC ${config.bitaccessBtm.apiKey}:${signature}`,
+          'x-date': dateString,
+          'Content-Type': contentType
+        }
+      }
+      const response = await fetch(request, options)
+      const result = await response.json()
+      const txs = result.result
+      for (const tx of txs) {
+        if (tx.status === 'complete') {
+          const date = new Date(tx.updated_at)
+          const timestamp = date.getTime() / 1000
+
+          const ssTx: StandardTx = {
+            status: 'complete',
+            inputTXID: tx.transaction_id,
+            inputAddress: tx.deposit_address,
+            inputCurrency: tx.deposit_currency.toUpperCase(),
+            inputAmount: tx.deposit_amount,
+            outputAddress: tx.withdrawal_address,
+            outputCurrency: tx.withdrawal_currency.toUpperCase(),
+            outputAmount: tx.withdrawal_amount.toString(),
+            timestamp
+          }
+          newTransactions.push(ssTx)
+        }
+      }
+
+      if (txs.length < PAGE_LIMIT) {
+        break
+      }
+    } catch (e) {
+      break
+    }
+    page++
+    if (page > SS_QUERY_PAGES) {
+      break
+    }
+  }
+  const out = {
+    diskCache,
+    newTransactions
+  }
+  return out
+}
+
+module.exports = { doBitaccessBtm }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -19,6 +19,7 @@ const { doSimplex } = require('./simplex.js')
 const { doBanxa } = require('./banxa.js')
 const { doBity } = require('./bity.js')
 const { doSwitchain } = require('./switchain.js')
+const { doBitaccessBtm } = require('./bitaccessBtm.js')
 const { bns } = require('biggystring')
 const config = require('../config.json')
 const { sprintf } = require('sprintf-js')
@@ -106,6 +107,11 @@ async function main (swapFuncParams: SwapFuncParams) {
     return {}
   })
 
+  const rBtm = await doBitaccessBtm(swapFuncParams).catch(e => {
+    console.error('doBitaccessBtm failed')
+    return {}
+  })
+
   printTxDataMap('CHN', rChn)
   printTxDataMap('CHA', rCha)
   printTxDataMap('FAA', rFaa)
@@ -125,6 +131,7 @@ async function main (swapFuncParams: SwapFuncParams) {
   printTxDataMap('BAN', rBan)
   printTxDataMap('BITY', rBity)
   printTxDataMap('SWI', rSwi)
+  printTxDataMap('BTM', rBtm)
   console.log(new Date(Date.now()))
 }
 
@@ -309,6 +316,9 @@ async function report (argv: Array<any>) {
     const bogResults = config.bog && config.bog.apiKey
       ? await doSummaryFunction(doBog)
       : {}
+    const btmResults = config.bitaccessBtm && config.bitaccessBtm.affiliateId
+      ? await doSummaryFunction(doBitaccessBtm)
+      : {}
 
     const simResults = await doSummaryFunction(doSimplex)
     const banResults = await doSummaryFunction(doBanxa)
@@ -419,6 +429,11 @@ async function report (argv: Array<any>) {
     console.log('\n***** Bity Daily *****')
     printTxDataMap('BITY', bityResults.daily)
 
+    console.log('\n***** Bitaccess BTM Monthly *****')
+    printTxDataMap('BTM', btmResults.monthly)
+    console.log('\n***** Bitaccess BTM Daily *****')
+    printTxDataMap('BTM', btmResults.daily)
+
     console.log('\n***** Swap Totals Monthly*****')
     printTxDataMap('TTS', results.monthly)
     console.log('\n***** Swap Totals Daily *****')
@@ -436,6 +451,7 @@ async function report (argv: Array<any>) {
     combineResults(fiatResults, simResults)
     combineResults(fiatResults, banResults)
     combineResults(fiatResults, bityResults)
+    combineResults(fiatResults, btmResults)
 
     console.log('\n***** Fiat Totals Monthly *****')
     printTxDataMap('TTF', fiatResults.monthly)


### PR DESCRIPTION
Integration for the BTM Cash API, as requested. Followed the outline from the Faast integration, though this one's a crypto->fiat service. I also needed to add a file to flowconfig ignore list as I was having errors on precommit.