### PR TITLE
Changed Banxa to use API

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -7,6 +7,7 @@
   "coinMarketCapAPiKey": "xxx",
   "shapeShiftApiKey": "xxx",
   "shapeShiftToken": "xxx",
+  "banxaToken": "xxx",
   "libertyXApiKey": "xxx",
   "changellyApiKey": "xxx",
   "changenowApiKey": "xxx",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "json-format": "^1.0.1",
     "jsonfile": "^4.0.0",
     "node-fetch": "^1.7.3",
+    "sleep": "^6.3.0",
     "sprintf-js": "^1.1.1",
     "web3": "^1.0.0-beta.52"
   },

--- a/src/banxa.js
+++ b/src/banxa.js
@@ -62,7 +62,7 @@ function processOrders (orders, ssFormatTxs) {
       const dateTimeParts = origDateTime.split(' ')
       const dateParts = dateTimeParts[0].split('-')
       const month = MONTH_MAP[dateParts[1]]
-      const reformattedDate = `${dateParts[2]}-${month}-${dateParts[0]}T${dateTimeParts[1]}`
+      const reformattedDate = `${dateParts[2]}-${month}-${dateParts[0]}T${dateTimeParts[1]}Z`
 
       // Flip the amounts if the order is a SELL
       let inputAmount = order.fiat_amount

--- a/src/banxa.js
+++ b/src/banxa.js
@@ -1,12 +1,29 @@
 // @flow
 import type { StandardTx, SwapFuncParams } from './checkSwapService.js'
 const js = require('jsonfile')
-const fs = require('fs')
+const fetch = require('node-fetch')
 const { checkSwapService } = require('./checkSwapService.js')
-const csv = require('csvtojson')
+const crypto = require('crypto')
+const sleep = require('sleep')
+const confFileName = './config.json'
+const config = js.readFileSync(confFileName)
 
 const BANXA_CACHE = './cache/banRaw.json'
-const BANXA_FOLDER = './cache/banxa'
+
+const MONTH_MAP = {
+  'Jan': '01',
+  'Feb': '02',
+  'Mar': '03',
+  'Apr': '04',
+  'May': '05',
+  'Jun': '06',
+  'Jul': '07',
+  'Aug': '08',
+  'Sep': '09',
+  'Oct': '10',
+  'Nov': '11',
+  'Dec': '12'
+}
 
 async function doBanxa (swapFuncParams: SwapFuncParams) {
   return checkSwapService(fetchBanxa,
@@ -16,56 +33,137 @@ async function doBanxa (swapFuncParams: SwapFuncParams) {
   )
 }
 
+async function callBanxaAPI (queryDate, pageLimit, page) {
+  const nonce = Math.floor(new Date() / 1000)
+
+  const apiQuery = `/api/orders?start_date=${queryDate}&end_date=${queryDate}&per_page=${pageLimit}&page=${page}`
+
+  const text = `GET\n${apiQuery}\n${nonce}`
+  const secret = config.banxaToken
+  const key = 'EDGE'
+  const hmac = crypto.createHmac('sha256', secret)
+    .update(text)
+    .digest('hex')
+  const authHeader = key + ':' + hmac + ':' + nonce
+
+  const headers = {
+    'Authorization': 'Bearer ' + authHeader,
+    'Content-Type': 'application/json'
+  }
+
+  return fetch(`https://edge.banxa.com${apiQuery}`, {headers: headers})
+}
+
+function processOrders (orders, ssFormatTxs) {
+  for (const order of orders) {
+    if (order.status === 'complete') {
+      // Reformat the date from DD-MMM-YYYY HH:MM:SS to YYYY-MM-DDTHH:MM:SS
+      const origDateTime = order.created_at
+      const dateTimeParts = origDateTime.split(' ')
+      const dateParts = dateTimeParts[0].split('-')
+      const month = MONTH_MAP[dateParts[1]]
+      const reformattedDate = `${dateParts[2]}-${month}-${dateParts[0]}T${dateTimeParts[1]}`
+
+      // Flip the amounts if the order is a SELL
+      let inputAmount = order.fiat_amount
+      let inputCurrency = order.fiat_code
+      let outputAmount = order.coin_amount
+      let outputCurrency = order.coin_code
+      if (order.order_type === 'CRYPTO-SELL') {
+        inputAmount = order.coin_amount
+        inputCurrency = order.coin_code
+        outputAmount = order.fiat_amount
+        outputCurrency = order.fiat_code
+      }
+
+      const ssTx: StandardTx = {
+        status: 'complete',
+        inputTXID: order.ref.toString(),
+        inputAddress: '',
+        inputCurrency: inputCurrency,
+        inputAmount: inputAmount,
+        outputAddress: order.wallet_address,
+        outputCurrency: outputCurrency,
+        outputAmount: outputAmount,
+        timestamp: new Date(reformattedDate).getTime() / 1000
+      }
+      ssFormatTxs.push(ssTx)
+    }
+  }
+}
+
 async function fetchBanxa (swapFuncParams: SwapFuncParams) {
   if (!swapFuncParams.useCache) {
-    console.log('Fetching Banxa from CSV...')
+    console.log('Fetching Banxa from API...')
   }
-  let diskCache = { txs: [] }
+  let diskCache = { last_date: '2019-08-26', txs: [] }
 
   try {
     diskCache = js.readFileSync(BANXA_CACHE)
   } catch (e) {}
-
-  const transactionMap = {}
   const ssFormatTxs: Array<StandardTx> = []
 
-  const files = await fs.readdirSync(BANXA_FOLDER)
+  const lastDate = new Date(diskCache.last_date)
 
-  for (const fileName of files) {
-    const filePath = `./cache/banxa/${fileName}`
-    const csvData = await csv().fromFile(filePath)
-    for (const order of csvData) {
-      let date
-      if (order['UTC Time']) {
-        date = new Date(order['UTC Time'])
-      } else if (order['Completed At (UTC)']) {
-        date = new Date(order['Completed At (UTC)'])
-      } else {
-        continue
+  // Go back a week just to make sure you capture any late completing orders
+  lastDate.setTime(lastDate.getTime() - (7 * 86400000))
+
+  const now = new Date()
+  const today = new Date(now.toISOString().split('T')[0]).getTime()
+
+  let queryDate = lastDate.toISOString().split('T')[0]
+
+  if (!swapFuncParams.useCache) {
+    console.log(`BANXA: Loading orders starting from ${queryDate}`)
+    // Loop through the days
+    while (lastDate.getTime() !== today) {
+      let page = 1
+      const pageLimit = 100
+      queryDate = lastDate.toISOString().split('T')[0]
+      // Move last date on 1 day
+      lastDate.setTime(lastDate.getTime() + 86400000)
+      let attempt = 0
+
+      // Loop through the pages for this day
+      while (1) {
+        let orders = []
+
+        let apiResponse
+        while (attempt < 3) {
+          console.log(`BANXA: Calling API with date ${queryDate}, result size ${pageLimit} and offset ${page} for attempt ${attempt}`)
+          apiResponse = await callBanxaAPI(queryDate, pageLimit, page)
+          const status = await apiResponse.status
+          // Handle the situation where the API is rate limiting the requests
+          if (status !== 200) {
+            console.log(`BANXA: Response code ${status}. Retrying after 2 second sleep...`)
+            sleep.sleep(2)
+            attempt++
+          } else {
+            break
+          }
+        }
+        if (attempt === 3) break
+
+        if (apiResponse) {
+          const ordersData = await apiResponse.json()
+
+          if (ordersData && ordersData.data && ordersData.data.orders.length) orders = ordersData.data.orders
+          else break
+
+          processOrders(orders, ssFormatTxs)
+
+          if (orders.length < pageLimit) break
+          page++
+        }
       }
-      const timestamp = date.getTime() / 1000
-      const uniqueIdentifier = order['Order Id']
-      const ssTx: StandardTx = {
-        status: 'complete',
-        inputTXID: uniqueIdentifier,
-        inputAddress: '',
-        inputCurrency: order['Source Currency'],
-        inputAmount: parseFloat(order['Source Amount']),
-        outputAddress: '',
-        outputCurrency: order['Target Currency'],
-        outputAmount: order['Target Amount'],
-        timestamp: timestamp
+      if (attempt === 3) {
+        console.log(`BANXA: Unable to process date ${queryDate}`)
+        break
       }
-      // console.log('ssTx: ', ssTx)
-      transactionMap[uniqueIdentifier] = ssTx
     }
   }
-  for (const id in transactionMap) {
-    ssFormatTxs.push(transactionMap[id])
-    ssFormatTxs.sort((a, b) => a.timestamp - b.timestamp)
-  }
 
-  // console.log('ssFormatTxs is: ', ssFormatTxs)
+  diskCache.last_date = queryDate
 
   const out = {
     diskCache,


### PR DESCRIPTION
Update to Banxa to use their API instead of CSV files. The banxaToken should be set to the production private key that you should have received from us on account creation. If you do not have this then speak to Jan to get this again. 

I needed to add one additional module for sleep as if you are regenerating a lot of the data, then there is a chance you could hit the throttle limit so this will allow it to sleep for a period before trying again. If this does fail then it will store the date and the data it got up to and start from that point on the next run

Finally I actually push the date back by a week when it starts since some of our payments can be delayed by a few days due to over weekend processing of bank transfers hence a pending order could still go to complete after 4 days.

I will send the new banRaw.json file back to you over slack